### PR TITLE
docs(app): added instruction on how to push initial commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ To run the app on Android
 pnpm android
 ```
 
+To push the initial commit
+
+```sh
+# bypass the husky hook by `--no-verify`
+git commit -m 'feat: initial commit' --no-verify`
+```
+
 ## ✍️ Documentation
 
 - [Rules and Conventions](https://starter.obytes.com/getting-started/rules-and-conventions/)


### PR DESCRIPTION
## What does this do?

Added instruction on how to push the initial commit

## Why did you do this?

you will end up with this error if you will not follow the instruction
```sh
fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
husky - pre-commit hook exited with code 128 (error)
```

## Who/what does this impact?

all for all initial commits

## How did you test this?

by running commit without bypassing husky hooks
