### PR TITLE
chore(app): added necessary keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ yarn-error.log
 /coverage
 # macOS
 .DS_Store
+.env.*
+/secret


### PR DESCRIPTION
## What does this do?

will authorise the app to perform CI actions that require keys

## Why did you do this?

created keys from Github secrets and Expo secrets

## Who/what does this impact?

all

## How did you test this?

n/a
