### PR TITLE
feat(app): rearranged the template of obytes to separate my deliveroo

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -14,15 +14,15 @@ PODS:
     - ExpoModulesCore
   - Expo (49.0.13):
     - ExpoModulesCore
-  - expo-dev-client (2.4.11):
+  - expo-dev-client (2.4.12):
     - EXManifests
     - expo-dev-launcher
     - expo-dev-menu
     - expo-dev-menu-interface
     - EXUpdatesInterface
-  - expo-dev-launcher (2.4.13):
+  - expo-dev-launcher (2.4.14):
     - EXManifests
-    - expo-dev-launcher/Main (= 2.4.13)
+    - expo-dev-launcher/Main (= 2.4.14)
     - expo-dev-menu
     - expo-dev-menu-interface
     - ExpoModulesCore
@@ -30,7 +30,7 @@ PODS:
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
     - React-RCTAppDelegate
-  - expo-dev-launcher/Main (2.4.13):
+  - expo-dev-launcher/Main (2.4.14):
     - EXManifests
     - expo-dev-launcher/Unsafe
     - expo-dev-menu
@@ -40,7 +40,7 @@ PODS:
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
     - React-RCTAppDelegate
-  - expo-dev-launcher/Unsafe (2.4.13):
+  - expo-dev-launcher/Unsafe (2.4.14):
     - EXManifests
     - expo-dev-menu
     - expo-dev-menu-interface
@@ -49,27 +49,27 @@ PODS:
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
     - React-RCTAppDelegate
-  - expo-dev-menu (3.2.1):
-    - expo-dev-menu/Main (= 3.2.1)
+  - expo-dev-menu (3.2.2):
+    - expo-dev-menu/Main (= 3.2.2)
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
   - expo-dev-menu-interface (1.3.0)
-  - expo-dev-menu/Main (3.2.1):
+  - expo-dev-menu/Main (3.2.2):
     - EXManifests
     - expo-dev-menu-interface
     - expo-dev-menu/Vendored
     - ExpoModulesCore
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - expo-dev-menu/SafeAreaView (3.2.1):
+  - expo-dev-menu/SafeAreaView (3.2.2):
     - ExpoModulesCore
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - expo-dev-menu/Vendored (3.2.1):
+  - expo-dev-menu/Vendored (3.2.2):
     - expo-dev-menu/SafeAreaView
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - ExpoImage (1.3.4):
+  - ExpoImage (1.3.5):
     - ExpoModulesCore
     - SDWebImage (~> 5.15.8)
     - SDWebImageAVIFCoder (~> 0.10.0)
@@ -836,11 +836,11 @@ SPEC CHECKSUMS:
   EXJSONUtils: 6802be4282d42b97c51682468ddc1026a06f8276
   EXManifests: 8a4a480e3b58891d5657d3996a39229e5c96d912
   Expo: e7d2116b947e2e6fdeb09ee4f2754f819426d1b6
-  expo-dev-client: a97a68508a6104ad99f4b2613fd808cda7a4186c
-  expo-dev-launcher: 7336e6dc8ed51b87225f8a96d787add81a99748c
-  expo-dev-menu: 9542570483a647626570cb4333c80add4cea1254
+  expo-dev-client: 1e20e0d67534fd63da37604747a60e7d69fc46f5
+  expo-dev-launcher: e9411e0c91abaa448682d0fa688957e7dbff356e
+  expo-dev-menu: f7036f78c69f0f6ecb386f5543a06266dde64bf5
   expo-dev-menu-interface: bda969497e73dadc2663c479e0fa726ca79a306e
-  ExpoImage: 912063c1082ed72f8ae6bbbe0196602257022fa9
+  ExpoImage: 723efcb8d9377ae8645a6f7a1579305f5b80a76f
   ExpoKeepAwake: be4cbd52d9b177cde0fd66daa1913afa3161fc1d
   ExpoLocalization: be37fdd0b5930c6a49cd307b4542f4b426d6134c
   ExpoModulesCore: 51cb2e7ab4c8da14be3f40b66d54c1781002e99d

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@gorhom/bottom-sheet": "^4.5.1",
     "@hookform/resolvers": "^2.9.11",
     "@react-navigation/bottom-tabs": "^6.5.7",
+    "@react-navigation/drawer": "^6.6.6",
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/native-stack": "^6.9.12",
     "@shopify/flash-list": "1.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ dependencies:
   '@react-navigation/bottom-tabs':
     specifier: ^6.5.7
     version: 6.5.7(@react-navigation/native@6.1.6)(react-native-safe-area-context@4.6.3)(react-native-screens@3.22.1)(react-native@0.72.6)(react@18.2.0)
+  '@react-navigation/drawer':
+    specifier: ^6.6.6
+    version: 6.6.6(@react-navigation/native@6.1.6)(react-native-gesture-handler@2.12.0)(react-native-reanimated@3.3.0)(react-native-safe-area-context@4.6.3)(react-native-screens@3.22.1)(react-native@0.72.6)(react@18.2.0)
   '@react-navigation/native':
     specifier: ^6.1.6
     version: 6.1.6(react-native@0.72.6)(react@18.2.0)
@@ -3501,8 +3504,45 @@ packages:
       use-latest-callback: 0.1.5
     dev: false
 
+  /@react-navigation/drawer@6.6.6(@react-navigation/native@6.1.6)(react-native-gesture-handler@2.12.0)(react-native-reanimated@3.3.0)(react-native-safe-area-context@4.6.3)(react-native-screens@3.22.1)(react-native@0.72.6)(react@18.2.0):
+    resolution: {integrity: sha512-DW/oNRisSOGOqvZfCzfhKBxnzT97Teqtg1Gal85g+K3gnVbM1jOBE2PdnYsKU0fULfFtDwvp/QZSbcgjDpr12A==}
+    peerDependencies:
+      '@react-navigation/native': ^6.0.0
+      react: '*'
+      react-native: '*'
+      react-native-gesture-handler: '>= 1.0.0'
+      react-native-reanimated: '>= 1.0.0'
+      react-native-safe-area-context: '>= 3.0.0'
+      react-native-screens: '>= 3.0.0'
+    dependencies:
+      '@react-navigation/elements': 1.3.21(@react-navigation/native@6.1.6)(react-native-safe-area-context@4.6.3)(react-native@0.72.6)(react@18.2.0)
+      '@react-navigation/native': 6.1.6(react-native@0.72.6)(react@18.2.0)
+      color: 4.2.3
+      react: 18.2.0
+      react-native: 0.72.6(@babel/core@7.21.0)(@babel/preset-env@7.22.10)(react@18.2.0)
+      react-native-gesture-handler: 2.12.0(react-native@0.72.6)(react@18.2.0)
+      react-native-reanimated: 3.3.0(@babel/core@7.21.0)(@babel/plugin-proposal-nullish-coalescing-operator@7.18.6)(@babel/plugin-proposal-optional-chaining@7.21.0)(@babel/plugin-transform-arrow-functions@7.22.5)(@babel/plugin-transform-shorthand-properties@7.22.5)(@babel/plugin-transform-template-literals@7.22.5)(react-native@0.72.6)(react@18.2.0)
+      react-native-safe-area-context: 4.6.3(react-native@0.72.6)(react@18.2.0)
+      react-native-screens: 3.22.1(react-native@0.72.6)(react@18.2.0)
+      warn-once: 0.1.1
+    dev: false
+
   /@react-navigation/elements@1.3.17(@react-navigation/native@6.1.6)(react-native-safe-area-context@4.6.3)(react-native@0.72.6)(react@18.2.0):
     resolution: {integrity: sha512-sui8AzHm6TxeEvWT/NEXlz3egYvCUog4tlXA4Xlb2Vxvy3purVXDq/XsM56lJl344U5Aj/jDzkVanOTMWyk4UA==}
+    peerDependencies:
+      '@react-navigation/native': ^6.0.0
+      react: '*'
+      react-native: '*'
+      react-native-safe-area-context: '>= 3.0.0'
+    dependencies:
+      '@react-navigation/native': 6.1.6(react-native@0.72.6)(react@18.2.0)
+      react: 18.2.0
+      react-native: 0.72.6(@babel/core@7.21.0)(@babel/preset-env@7.22.10)(react@18.2.0)
+      react-native-safe-area-context: 4.6.3(react-native@0.72.6)(react@18.2.0)
+    dev: false
+
+  /@react-navigation/elements@1.3.21(@react-navigation/native@6.1.6)(react-native-safe-area-context@4.6.3)(react-native@0.72.6)(react@18.2.0):
+    resolution: {integrity: sha512-eyS2C6McNR8ihUoYfc166O1D8VYVh9KIl0UQPI8/ZJVsStlfSTgeEEh+WXge6+7SFPnZ4ewzEJdSAHH+jzcEfg==}
     peerDependencies:
       '@react-navigation/native': ^6.0.0
       react: '*'

--- a/src/navigation/drawer-navigator.tsx
+++ b/src/navigation/drawer-navigator.tsx
@@ -1,0 +1,46 @@
+import { createDrawerNavigator } from '@react-navigation/drawer';
+import type { RouteProp } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { ComponentType } from 'react';
+import * as React from 'react';
+
+import { TabDeliveroo } from './tab-deliveroo';
+import { TabNavigator } from './tab-navigator';
+
+type DrawerParamList = {
+  TabNavigator: undefined;
+  TabDeliveroo: undefined;
+};
+
+type DrawerType = {
+  name: keyof DrawerParamList;
+  component: ComponentType<any>;
+  label: string;
+};
+
+const Drawer = createDrawerNavigator<DrawerParamList>();
+
+export type DrawerList<T extends keyof DrawerParamList> = {
+  navigation: NativeStackNavigationProp<DrawerParamList, T>;
+  route: RouteProp<DrawerParamList, T>;
+};
+
+const drawers: DrawerType[] = [
+  { name: 'TabNavigator', component: TabNavigator, label: 'TabNavigator' },
+  { name: 'TabDeliveroo', component: TabDeliveroo, label: 'TabDeliveroo' },
+];
+
+export const DrawerNavigator = () => {
+  return (
+    <Drawer.Navigator>
+      {drawers.map(({ name, component, label }) => (
+        <Drawer.Screen
+          key={name}
+          name={name}
+          component={component}
+          options={{ title: label, headerShown: false }}
+        />
+      ))}
+    </Drawer.Navigator>
+  );
+};

--- a/src/navigation/root-navigator.tsx
+++ b/src/navigation/root-navigator.tsx
@@ -7,8 +7,8 @@ import { useIsFirstTime } from '@/core/hooks';
 import { Onboarding } from '@/screens';
 
 import { AuthNavigator } from './auth-navigator';
+import { DrawerNavigator } from './drawer-navigator';
 import { NavigationContainer } from './navigation-container';
-import { TabNavigator } from './tab-navigator';
 const Stack = createNativeStackNavigator();
 
 export const Root = () => {
@@ -38,7 +38,7 @@ export const Root = () => {
           {status === 'signOut' ? (
             <Stack.Screen name="Auth" component={AuthNavigator} />
           ) : (
-            <Stack.Screen name="App" component={TabNavigator} />
+            <Stack.Screen name="App" component={DrawerNavigator} />
           )}
         </Stack.Group>
       )}

--- a/src/navigation/tab-deliveroo.tsx
+++ b/src/navigation/tab-deliveroo.tsx
@@ -1,0 +1,95 @@
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { useColorScheme } from 'nativewind';
+import type { ComponentType } from 'react';
+import * as React from 'react';
+import type { SvgProps } from 'react-native-svg';
+
+import { Tab1, Tab2, Tab3 } from '@/screens';
+import {
+  colors,
+  Rate as RateIcon,
+  Share as ShareIcon,
+  Website as WebsiteIcon,
+} from '@/ui';
+
+type TabParamList = {
+  Tab1: undefined;
+  Tab2: undefined;
+  Tab3: undefined;
+};
+
+type TabType = {
+  name: keyof TabParamList;
+  component: ComponentType<any>;
+  label: string;
+};
+
+type TabIconsType = {
+  [key in keyof TabParamList]: (props: SvgProps) => JSX.Element;
+};
+
+const Tab = createBottomTabNavigator<TabParamList>();
+
+const tabsIcons: TabIconsType = {
+  Tab1: (props: SvgProps) => <ShareIcon {...props} />,
+  Tab2: (props: SvgProps) => <RateIcon {...props} />,
+  Tab3: (props: SvgProps) => <WebsiteIcon {...props} />,
+};
+
+const tabs: TabType[] = [
+  {
+    name: 'Tab1',
+    component: Tab1,
+    label: 'Tab1',
+  },
+  {
+    name: 'Tab2',
+    component: Tab2,
+    label: 'Tab2',
+  },
+  {
+    name: 'Tab3',
+    component: Tab3,
+    label: 'Tab3',
+  },
+];
+
+type BarIconType = {
+  name: keyof TabParamList;
+  color: string;
+};
+
+const BarIcon = ({ color, name, ...reset }: BarIconType) => {
+  const Icon = tabsIcons[name];
+  return <Icon color={color} {...reset} />;
+};
+
+export const TabDeliveroo = () => {
+  const { colorScheme } = useColorScheme();
+  return (
+    <Tab.Navigator
+      screenOptions={({ route }) => ({
+        tabBarInactiveTintColor:
+          colorScheme === 'dark' ? colors.charcoal[400] : colors.neutral[400],
+        // eslint-disable-next-line react/no-unstable-nested-components
+        tabBarIcon: ({ color }) => <BarIcon name={route.name} color={color} />,
+      })}
+    >
+      <Tab.Group screenOptions={{ headerShown: false }}>
+        {tabs.map(({ name, component, label }) => {
+          return (
+            <Tab.Screen
+              key={name}
+              name={name}
+              component={component}
+              options={{
+                title: label,
+                tabBarTestID: `${name}-tab-deliveroo`,
+              }}
+            />
+          );
+        })}
+      </Tab.Group>
+    </Tab.Navigator>
+  );
+};

--- a/src/screens/index.tsx
+++ b/src/screens/index.tsx
@@ -3,3 +3,6 @@ export * from './login';
 export * from './onboarding';
 export * from './settings';
 export * from './style';
+export * from './tab1';
+export * from './tab2';
+export * from './tab3';

--- a/src/screens/tab1/index.tsx
+++ b/src/screens/tab1/index.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+import { FocusAwareStatusBar, SafeAreaView, Text } from '@/ui';
+
+export const Tab1 = () => {
+  return (
+    <SafeAreaView className="flex-1">
+      <FocusAwareStatusBar />
+
+      <Text className="text-base">Tab1 Component</Text>
+    </SafeAreaView>
+  );
+};

--- a/src/screens/tab2/index.tsx
+++ b/src/screens/tab2/index.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+import { FocusAwareStatusBar, SafeAreaView, Text } from '@/ui';
+
+export const Tab2 = () => {
+  return (
+    <SafeAreaView className="flex-1">
+      <FocusAwareStatusBar />
+
+      <Text className="text-base">Tab2 Component</Text>
+    </SafeAreaView>
+  );
+};

--- a/src/screens/tab3/index.tsx
+++ b/src/screens/tab3/index.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+import { FocusAwareStatusBar, SafeAreaView, Text } from '@/ui';
+
+export const Tab3 = () => {
+  return (
+    <SafeAreaView className="flex-1">
+      <FocusAwareStatusBar />
+
+      <Text className="text-base">Tab3 Component</Text>
+    </SafeAreaView>
+  );
+};


### PR DESCRIPTION
## What does this do?

added template for deliveroo screens in a drawer navigation then thru tab navigation

## Why did you do this?

to add space for the deliveroo app

## Who/what does this impact?

main app

## How did you test this?

not tested
